### PR TITLE
Don't do unnecessary upgrade in docker image

### DIFF
--- a/docker/shotcut-build/Dockerfile
+++ b/docker/shotcut-build/Dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:14.04
 MAINTAINER dan@dennedy.org
 
 RUN apt-get update -qq \
-  && apt-get -yqq upgrade \
   && apt-get install -yqq gcc-mingw-w64-x86-64 git automake \
   autoconf libtool intltool g++ yasm libmp3lame-dev libsamplerate-dev \
   libxml2-dev ladspa-sdk libjack-dev libsox-dev libsdl2-dev libgtk2.0-dev \

--- a/docker/shotcut-build/Dockerfile
+++ b/docker/shotcut-build/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:14.04
 MAINTAINER dan@dennedy.org
 
-RUN apt-get update \
-  && apt-get -y upgrade \
-  && apt-get install -y gcc-mingw-w64-x86-64 git automake \
+RUN apt-get update -qq \
+  && apt-get -yqq upgrade \
+  && apt-get install -yqq gcc-mingw-w64-x86-64 git automake \
   autoconf libtool intltool g++ yasm libmp3lame-dev libsamplerate-dev \
   libxml2-dev ladspa-sdk libjack-dev libsox-dev libsdl2-dev libgtk2.0-dev \
   libxslt1-dev libexif-dev libdv-dev libtheora-dev \


### PR DESCRIPTION
You can avoid unnecessary package downloads by not running plain "apt-get upgrade" in the script.

All dependent packages to the one you explicit install will be upgraded so no need to upgrade other stuff.

Also the -qq silence the output a bit so logs does not get overflown.